### PR TITLE
fix: セッション残存時にやり直し・キャンセルボタンを表示

### DIFF
--- a/src/interactions/buttons.js
+++ b/src/interactions/buttons.js
@@ -23,8 +23,22 @@ export async function handleButton(interaction, env) {
   if (customId === 'intro_start') {
     const existing = await get(kv, userId)
     if (existing) {
-      return ephemeralMsg('自己紹介の入力が途中です。続きから入力するか、キャンセルしてから再度お試しください。')
+      return ephemeralMsg('自己紹介の入力が途中です。最初からやり直すか、キャンセルできます。', [
+        {
+          type: 1,
+          components: [
+            { type: 2, custom_id: 'intro_restart', label: '最初からやり直す', style: 1 },
+            { type: 2, custom_id: 'intro_cancel', label: 'キャンセル', style: 2 },
+          ],
+        },
+      ])
     }
+    await create(kv, userId)
+    return showModal(buildModal1())
+  }
+
+  if (customId === 'intro_restart') {
+    await remove(kv, userId)
     await create(kv, userId)
     return showModal(buildModal1())
   }


### PR DESCRIPTION
## Summary
- 既存セッションがある状態で「✏️ 自己紹介を書く」を押した際、テキストのみでボタンがなく操作不能になっていた問題を修正
- 「最初からやり直す」ボタン — セッションをリセットしてモーダル1から再開
- 「キャンセル」ボタン — セッションを削除して終了

## Test plan
- [ ] セッション途中でエフェメラルを閉じた後、再度パネルボタンを押す → やり直し・キャンセルボタンが表示される
- [ ] 「最初からやり直す」→ モーダル1が開き、最初からフローを進められる
- [ ] 「キャンセル」→ セッションが削除され、再度パネルボタンから新規開始できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)