### PR TITLE
refactor(relay): コマンド構造の見直し - データ管理の明確化

### DIFF
--- a/src/commands/relay.js
+++ b/src/commands/relay.js
@@ -31,9 +31,10 @@ export async function handleRelay(interaction, env, ctx) {
   if (sub === 'start') return handleStart(kv, guildId, options, interaction, env, ctx)
   if (sub === 'status') return handleStatus(kv, guildId)
   if (sub === 'delete') return handleDelete(kv, guildId, options)
-  if (sub === 'end') return handleEnd(kv, guildId, options, interaction, env, ctx)
+  if (sub === 'end') return handleEnd(kv, guildId, interaction, env, ctx)
+  if (sub === 'post') return handlePost(kv, guildId, options, interaction, env, ctx)
   if (sub === 'reveal') return handleReveal(kv, guildId, options, interaction, env, ctx)
-  if (sub === 'cancel') return handleCancel(kv, guildId, interaction, env, ctx)
+  if (sub === 'terminate') return handleTerminate(kv, guildId, interaction, env, ctx)
 
   return ephemeralMsg('不明なサブコマンドです。')
 }
@@ -41,7 +42,7 @@ export async function handleRelay(interaction, env, ctx) {
 async function handleStart(kv, guildId, options, interaction, env, ctx) {
   const existing = await getRelay(kv, guildId)
   if (existing) {
-    return ephemeralMsg('既にリレーが進行中です。先に `/relay cancel` で中止してください。')
+    return ephemeralMsg('既にリレーが進行中です。先に `/relay terminate` で終了してください。')
   }
 
   const topic = options.topic
@@ -125,7 +126,34 @@ async function handleDelete(kv, guildId, options) {
   return ephemeralMsg(`${num}番目の文を削除しました（残り${relay.sentences.length}文）`)
 }
 
-async function handleEnd(kv, guildId, options, interaction, env, ctx) {
+async function handleEnd(kv, guildId, interaction, env, ctx) {
+  const relay = await getRelay(kv, guildId)
+  if (!relay) return ephemeralMsg('リレーは開催されていません。')
+
+  const applicationId = interaction.application_id
+  const interactionToken = interaction.token
+
+  if (ctx) {
+    ctx.waitUntil(doEnd(kv, guildId, relay, applicationId, interactionToken, env))
+  }
+  return { type: 5, data: { flags: EPHEMERAL } }
+}
+
+async function doEnd(kv, guildId, relay, applicationId, interactionToken, env) {
+  const { editMessage, sendFollowupMessage } = await import('../utils/discordApi.js')
+
+  await editMessage(relay.channelId, relay.messageId, env.DISCORD_TOKEN, {
+    content: `**📝 1文リレー終了**\nお題：**${relay.topic}**\n\n全${relay.sentences.length}文で完成しました！`,
+    components: [],
+  })
+
+  await sendFollowupMessage(applicationId, interactionToken, {
+    content: '✅ リレーを終了しました。追記はできなくなりました。',
+    flags: EPHEMERAL,
+  })
+}
+
+async function handlePost(kv, guildId, options, interaction, env, ctx) {
   const relay = await getRelay(kv, guildId)
   if (!relay) return ephemeralMsg('リレーは開催されていません。')
 
@@ -134,13 +162,13 @@ async function handleEnd(kv, guildId, options, interaction, env, ctx) {
   const interactionToken = interaction.token
 
   if (ctx) {
-    ctx.waitUntil(doEnd(kv, guildId, relay, targetChannelId, applicationId, interactionToken, env))
+    ctx.waitUntil(doPost(relay, targetChannelId, applicationId, interactionToken, env))
   }
   return { type: 5, data: { flags: EPHEMERAL } }
 }
 
-async function doEnd(kv, guildId, relay, targetChannelId, applicationId, interactionToken, env) {
-  const { postMessage, editMessage, sendFollowupMessage } = await import('../utils/discordApi.js')
+async function doPost(relay, targetChannelId, applicationId, interactionToken, env) {
+  const { postMessage, sendFollowupMessage } = await import('../utils/discordApi.js')
 
   const fullText = relay.sentences.map(s => s.text).join('')
   const header = `**お題：${relay.topic}**\n\n`
@@ -160,11 +188,6 @@ async function doEnd(kv, guildId, relay, targetChannelId, applicationId, interac
     return
   }
 
-  await editMessage(relay.channelId, relay.messageId, env.DISCORD_TOKEN, {
-    content: `**📝 1文リレー終了**\nお題：**${relay.topic}**\n\n全${relay.sentences.length}文で完成しました！`,
-    components: [],
-  })
-
   await sendFollowupMessage(applicationId, interactionToken, {
     content: '✅ 全文を投稿しました！',
     flags: EPHEMERAL,
@@ -180,12 +203,12 @@ async function handleReveal(kv, guildId, options, interaction, env, ctx) {
   const interactionToken = interaction.token
 
   if (ctx) {
-    ctx.waitUntil(doReveal(kv, guildId, relay, targetChannelId, applicationId, interactionToken, env))
+    ctx.waitUntil(doReveal(relay, targetChannelId, applicationId, interactionToken, env))
   }
   return { type: 5, data: { flags: EPHEMERAL } }
 }
 
-async function doReveal(kv, guildId, relay, targetChannelId, applicationId, interactionToken, env) {
+async function doReveal(relay, targetChannelId, applicationId, interactionToken, env) {
   const { postMessage, sendFollowupMessage } = await import('../utils/discordApi.js')
 
   const lines = relay.sentences.map((s, i) => `${i + 1}. ${s.text} — ${s.displayName}`)
@@ -206,15 +229,13 @@ async function doReveal(kv, guildId, relay, targetChannelId, applicationId, inte
     return
   }
 
-  await deleteRelay(kv, guildId)
-
   await sendFollowupMessage(applicationId, interactionToken, {
-    content: '✅ ネタバレを投稿しました。リレーデータを削除しました。',
+    content: '✅ ネタバレを投稿しました。',
     flags: EPHEMERAL,
   })
 }
 
-async function handleCancel(kv, guildId, interaction, env, ctx) {
+async function handleTerminate(kv, guildId, interaction, env, ctx) {
   const relay = await getRelay(kv, guildId)
   if (!relay) return ephemeralMsg('リレーは開催されていません。')
 
@@ -222,23 +243,23 @@ async function handleCancel(kv, guildId, interaction, env, ctx) {
   const interactionToken = interaction.token
 
   if (ctx) {
-    ctx.waitUntil(doCancel(kv, guildId, relay, applicationId, interactionToken, env))
+    ctx.waitUntil(doTerminate(kv, guildId, relay, applicationId, interactionToken, env))
   }
   return { type: 5, data: { flags: EPHEMERAL } }
 }
 
-async function doCancel(kv, guildId, relay, applicationId, interactionToken, env) {
+async function doTerminate(kv, guildId, relay, applicationId, interactionToken, env) {
   const { editMessage, sendFollowupMessage } = await import('../utils/discordApi.js')
 
   await editMessage(relay.channelId, relay.messageId, env.DISCORD_TOKEN, {
-    content: `**📝 1文リレー中止**\nお題：**${relay.topic}**`,
+    content: `**📝 1文リレー終了**\nお題：**${relay.topic}**\n\nデータは削除されました。`,
     components: [],
   })
 
   await deleteRelay(kv, guildId)
 
   await sendFollowupMessage(applicationId, interactionToken, {
-    content: '✅ リレーを中止しました。',
+    content: '✅ リレーデータを削除しました。',
     flags: EPHEMERAL,
   })
 }

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -201,7 +201,11 @@ const commands = [
     )
     .addSubcommand(sub =>
       sub.setName('end')
-        .setDescription('リレーを終了して全文を投稿します')
+        .setDescription('リレーを終了します（追記不可、データは残ります）')
+    )
+    .addSubcommand(sub =>
+      sub.setName('post')
+        .setDescription('全文を匿名で投稿します（データは残ります）')
         .addChannelOption(opt =>
           opt.setName('channel')
             .setDescription('投稿先チャンネル')
@@ -211,7 +215,7 @@ const commands = [
     )
     .addSubcommand(sub =>
       sub.setName('reveal')
-        .setDescription('ネタバレ（執筆者一覧）を投稿します')
+        .setDescription('ネタバレ（執筆者一覧）を投稿します（データは残ります）')
         .addChannelOption(opt =>
           opt.setName('channel')
             .setDescription('投稿先チャンネル')
@@ -220,8 +224,8 @@ const commands = [
         )
     )
     .addSubcommand(sub =>
-      sub.setName('cancel')
-        .setDescription('リレーを中止します（投稿なし）')
+      sub.setName('terminate')
+        .setDescription('リレーデータを削除します')
     )
     .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
     .toJSON(),

--- a/tests/relay.test.js
+++ b/tests/relay.test.js
@@ -143,11 +143,11 @@ describe('relay delete', () => {
 
 describe('relay end', () => {
   test('rejects when no relay active', async () => {
-    const result = await handleRelay(makeInteraction('end', { channel: 'ch-out' }), { SESSION_KV: createMockKV() })
+    const result = await handleRelay(makeInteraction('end'), { SESSION_KV: createMockKV() })
     expect(result.data.content).toContain('開催されていません')
   })
 
-  test('posts full text and disables button', async () => {
+  test('disables button and keeps data', async () => {
     mockFetch()
     const kv = createMockKV()
     await kv.put('relay-active:g123', JSON.stringify({
@@ -162,17 +162,9 @@ describe('relay end', () => {
     const env = { SESSION_KV: kv, DISCORD_TOKEN: 'test-tok' }
     let bgPromise
     const ctx = { waitUntil: (p) => { bgPromise = p } }
-    const result = await handleRelay(makeInteraction('end', { channel: 'ch-out' }), env, ctx)
+    const result = await handleRelay(makeInteraction('end'), env, ctx)
     expect(result.type).toBe(5)
     await bgPromise
-
-    const postCalls = fetchCalls.filter(c =>
-      c.url.includes('/channels/ch-out/messages') && c.options?.method === 'POST'
-    )
-    expect(postCalls.length).toBeGreaterThanOrEqual(1)
-    const body = JSON.parse(postCalls[0].options.body)
-    expect(body.content).toContain('一文目')
-    expect(body.content).toContain('二文目')
 
     const editCalls = fetchCalls.filter(c =>
       c.url.includes('/channels/ch1/messages/msg-panel') && c.options?.method === 'PATCH'
@@ -185,8 +177,40 @@ describe('relay end', () => {
   })
 })
 
+describe('relay post', () => {
+  test('posts full text anonymously and keeps data', async () => {
+    mockFetch()
+    const kv = createMockKV()
+    await kv.put('relay-active:g123', JSON.stringify({
+      topic: 'お題',
+      channelId: 'ch1',
+      messageId: 'msg-panel',
+      sentences: [
+        { text: '一文目', userId: 'u1', displayName: 'A' },
+        { text: '二文目', userId: 'u2', displayName: 'B' },
+      ],
+    }))
+    const env = { SESSION_KV: kv, DISCORD_TOKEN: 'test-tok' }
+    let bgPromise
+    const ctx = { waitUntil: (p) => { bgPromise = p } }
+    const result = await handleRelay(makeInteraction('post', { channel: 'ch-out' }), env, ctx)
+    expect(result.type).toBe(5)
+    await bgPromise
+
+    const postCalls = fetchCalls.filter(c =>
+      c.url.includes('/channels/ch-out/messages') && c.options?.method === 'POST'
+    )
+    expect(postCalls.length).toBeGreaterThanOrEqual(1)
+    const body = JSON.parse(postCalls[0].options.body)
+    expect(body.content).toContain('一文目')
+    expect(body.content).toContain('二文目')
+
+    expect(await kv.get('relay-active:g123')).not.toBeNull()
+  })
+})
+
 describe('relay reveal', () => {
-  test('posts spoiler and deletes KV', async () => {
+  test('posts spoiler and keeps data', async () => {
     mockFetch()
     const kv = createMockKV()
     await kv.put('relay-active:g123', JSON.stringify({
@@ -213,11 +237,11 @@ describe('relay reveal', () => {
     expect(body.content).toContain('A')
     expect(body.content).toContain('B')
 
-    expect(await kv.get('relay-active:g123')).toBeNull()
+    expect(await kv.get('relay-active:g123')).not.toBeNull()
   })
 })
 
-describe('relay cancel', () => {
+describe('relay terminate', () => {
   test('edits panel and deletes KV', async () => {
     mockFetch()
     const kv = createMockKV()
@@ -230,7 +254,7 @@ describe('relay cancel', () => {
     const env = { SESSION_KV: kv, DISCORD_TOKEN: 'test-tok' }
     let bgPromise
     const ctx = { waitUntil: (p) => { bgPromise = p } }
-    const result = await handleRelay(makeInteraction('cancel'), env, ctx)
+    const result = await handleRelay(makeInteraction('terminate'), env, ctx)
     expect(result.type).toBe(5)
     await bgPromise
 


### PR DESCRIPTION
## Summary

- `/relay end` — ボタン無効化のみ（投稿・データ削除なし）
- `/relay post #channel` — 全文を匿名投稿（新規、データ削除なし）
- `/relay reveal #channel` — ネタバレ投稿（データ削除なし）
- `/relay terminate` — データ削除（旧cancelを置き換え）

管理者が投稿とデータ削除のタイミングを自由にコントロールできるようになりました。

## Test plan
- [x] 全170テストがパス
- [ ] 実サーバーで end → post → reveal → terminate の一連フローを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)