### PR TITLE
fix: relay テストの lint エラーを修正

### DIFF
--- a/tests/relay.test.js
+++ b/tests/relay.test.js
@@ -4,7 +4,7 @@ function createMockKV() {
   const store = new Map()
   return {
     async get(key) { return store.get(key) ?? null },
-    async put(key, value, opts) { store.set(key, value) },
+    async put(key, value, _opts) { store.set(key, value) },
     async delete(key) { store.delete(key) },
   }
 }

--- a/tests/relayButton.test.js
+++ b/tests/relayButton.test.js
@@ -5,7 +5,7 @@ function createMockKV() {
   const store = new Map()
   return {
     async get(key) { return store.get(key) ?? null },
-    async put(key, value, opts) { store.set(key, value) },
+    async put(key, value, _opts) { store.set(key, value) },
     async delete(key) { store.delete(key) },
   }
 }

--- a/tests/relayStore.test.js
+++ b/tests/relayStore.test.js
@@ -4,7 +4,7 @@ function createMockKV() {
   const store = new Map()
   return {
     async get(key) { return store.get(key) ?? null },
-    async put(key, value, opts) { store.set(key, value) },
+    async put(key, value, _opts) { store.set(key, value) },
     async delete(key) { store.delete(key) },
   }
 }


### PR DESCRIPTION
## Summary

- テスト内の未使用引数 `opts` を `_opts` にリネーム（ESLint no-unused-vars 対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)