### PR TITLE
fix(relay): モーダル送信時の something went wrong エラーを修正

### DIFF
--- a/src/interactions/modals.js
+++ b/src/interactions/modals.js
@@ -54,7 +54,7 @@ function extractFields(interaction, keys) {
   return fields
 }
 
-export async function handleModalSubmit(interaction, env) {
+export async function handleModalSubmit(interaction, env, ctx) {
   const userId = getUserId(interaction)
   const customId = interaction.data.custom_id
 
@@ -75,7 +75,7 @@ export async function handleModalSubmit(interaction, env) {
 
   // Route relay modal
   if (customId === 'relay_modal') {
-    return handleRelayModal(interaction, env, userId)
+    return handleRelayModal(interaction, env, userId, ctx)
   }
 
   const kv = env.SESSION_KV
@@ -159,9 +159,8 @@ async function handleMatchupFreeTopics(interaction, env, userId) {
   return ephemeralMsg(`✅ 参加登録しました！ トピック: ${topicDisplay}`)
 }
 
-async function handleRelayModal(interaction, env, userId) {
-  const { getRelay, saveRelay } = await import('../utils/relayStore.js')
-  const { editMessage } = await import('../utils/discordApi.js')
+async function handleRelayModal(interaction, env, userId, ctx) {
+  const { getRelay } = await import('../utils/relayStore.js')
 
   const guildId = interaction.guild_id
   const relay = await getRelay(env.SESSION_KV, guildId)
@@ -176,12 +175,25 @@ async function handleRelayModal(interaction, env, userId) {
   if (!sentence) return ephemeralMsg('文が空です。')
 
   const displayName = getDisplayName(interaction)
+  const applicationId = interaction.application_id
+  const interactionToken = interaction.token
+
+  if (ctx) {
+    ctx.waitUntil(doRelayModalSubmit(env, guildId, relay, sentence, userId, displayName, applicationId, interactionToken))
+  }
+  return { type: 5, data: { flags: 64 } }
+}
+
+async function doRelayModalSubmit(env, guildId, relay, sentence, userId, displayName, applicationId, interactionToken) {
+  const { saveRelay } = await import('../utils/relayStore.js')
+  const { editMessage, sendFollowupMessage } = await import('../utils/discordApi.js')
+
   relay.sentences.push({ text: sentence, userId, displayName })
   await saveRelay(env.SESSION_KV, guildId, relay)
 
   const count = relay.sentences.length
 
-  editMessage(relay.channelId, relay.messageId, env.DISCORD_TOKEN, {
+  await editMessage(relay.channelId, relay.messageId, env.DISCORD_TOKEN, {
     content: `**📝 1文リレー開催中！**\nお題：**${relay.topic}**\n\n現在 ${count} 文目`,
     components: [{
       type: 1,
@@ -192,7 +204,10 @@ async function handleRelayModal(interaction, env, userId) {
         style: 1,
       }],
     }],
-  }).catch(err => console.error('relay panel update failed:', err))
+  })
 
-  return ephemeralMsg(`✅ 追加しました！（${count}文目）`)
+  await sendFollowupMessage(applicationId, interactionToken, {
+    content: `✅ 追加しました！（${count}文目）`,
+    flags: 64,
+  })
 }

--- a/src/modals/relayModal.js
+++ b/src/modals/relayModal.js
@@ -4,9 +4,13 @@
  */
 export function buildRelayModal(previousSentence) {
   const maxTitleLen = 45
-  let title = previousSentence || '最初の一文に続けてください'
-  if (title.length > maxTitleLen) {
-    title = title.slice(0, maxTitleLen - 1) + '…'
+  // タイトルに使えない文字（改行等）を除去し、長さを制限する
+  let title = (previousSentence || '最初の一文に続けてください')
+    .replace(/[\n\r]+/g, ' ')
+    .trim()
+  if (!title) title = '最初の一文に続けてください'
+  if ([...title].length > maxTitleLen) {
+    title = [...title].slice(0, maxTitleLen - 1).join('') + '…'
   }
 
   return {

--- a/src/worker.js
+++ b/src/worker.js
@@ -88,7 +88,7 @@ export default {
       } else if (interaction.type === InteractionType.MESSAGE_COMPONENT) {
         result = await handleButton(interaction, env)
       } else if (interaction.type === InteractionType.MODAL_SUBMIT) {
-        result = await handleModalSubmit(interaction, env)
+        result = await handleModalSubmit(interaction, env, ctx)
       } else {
         return new Response('Unknown interaction', { status: 400 })
       }

--- a/tests/relayButton.test.js
+++ b/tests/relayButton.test.js
@@ -84,7 +84,7 @@ describe('relay_add button', () => {
 })
 
 describe('relay_modal submit', () => {
-  test('adds sentence and returns success', async () => {
+  test('returns deferred and saves sentence in background', async () => {
     mockFetch()
     const kv = createMockKV()
     await kv.put('relay-active:g123', JSON.stringify({
@@ -94,8 +94,11 @@ describe('relay_modal submit', () => {
       sentences: [{ text: '前の文', userId: 'u-other', displayName: 'Other' }],
     }))
     const env = { SESSION_KV: kv, DISCORD_TOKEN: 'test-tok' }
-    const result = await handleModalSubmit(makeModalInteraction('新しい文'), env)
-    expect(result.data.content).toContain('追加しました')
+    let bgPromise
+    const ctx = { waitUntil: (p) => { bgPromise = p } }
+    const result = await handleModalSubmit(makeModalInteraction('新しい文'), env, ctx)
+    expect(result.type).toBe(5)
+    await bgPromise
 
     const relay = JSON.parse(await kv.get('relay-active:g123'))
     expect(relay.sentences).toHaveLength(2)


### PR DESCRIPTION
## Summary

- モーダル送信ハンドラを deferred パターン（type:5 + waitUntil）に変更
- KV書き込み + パネル更新をバックグラウンド処理にすることで3秒タイムアウトを回避
- worker.js で `handleModalSubmit` に `ctx` を渡すように変更
- モーダルタイトルのサニタイズ（改行除去、Unicode対応の切り詰め）も追加

## Test plan
- [x] 全170テストがパス
- [ ] 実サーバーで一文追加時に「something went wrong」が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)