### PR TITLE
feat(relay): add /relay help subcommand

### DIFF
--- a/src/commands/relay.js
+++ b/src/commands/relay.js
@@ -28,6 +28,7 @@ export async function handleRelay(interaction, env, ctx) {
   const guildId = interaction.guild_id
   const { sub, options } = getSubcommand(interaction)
 
+  if (sub === 'help') return handleHelp()
   if (sub === 'start') return handleStart(kv, guildId, options, interaction, env, ctx)
   if (sub === 'status') return handleStatus(kv, guildId)
   if (sub === 'delete') return handleDelete(kv, guildId, options)
@@ -37,6 +38,36 @@ export async function handleRelay(interaction, env, ctx) {
   if (sub === 'terminate') return handleTerminate(kv, guildId, interaction, env, ctx)
 
   return ephemeralMsg('不明なサブコマンドです。')
+}
+
+function handleHelp() {
+  const text = [
+    '**📖 /relay コマンドの使い方**',
+    '',
+    '`/relay start topic:<お題> first_sentence:<最初の一文>`',
+    '　リレーを開始します。パネルが投稿され、参加者がボタンで一文を追加できます。',
+    '',
+    '`/relay status`',
+    '　現在の全文と執筆者を確認します（自分だけに表示）。',
+    '',
+    '`/relay delete number:<番号>`',
+    '　指定した番号の文を削除します。',
+    '',
+    '`/relay end`',
+    '　リレーを終了します。追記ボタンが無効になりますが、データは残ります。',
+    '',
+    '`/relay post channel:<チャンネル>`',
+    '　全文を匿名で指定チャンネルに投稿します。',
+    '',
+    '`/relay reveal channel:<チャンネル>`',
+    '　執筆者一覧（ネタバレ）を指定チャンネルに投稿します。',
+    '',
+    '`/relay terminate`',
+    '　リレーのデータを完全に削除します。',
+    '',
+    '**💡 基本の流れ:** `start` → ボタンで参加 → `end` → `post` → `reveal` → `terminate`',
+  ].join('\n')
+  return ephemeralMsg(text)
 }
 
 async function handleStart(kv, guildId, options, interaction, env, ctx) {

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -172,6 +172,10 @@ const commands = [
     .setName('relay')
     .setDescription('1文リレーイベント機能')
     .addSubcommand(sub =>
+      sub.setName('help')
+        .setDescription('コマンドの使い方を表示します')
+    )
+    .addSubcommand(sub =>
       sub.setName('start')
         .setDescription('リレーを開始します')
         .addStringOption(opt =>

--- a/tests/relay.test.js
+++ b/tests/relay.test.js
@@ -64,6 +64,22 @@ describe('relay — permission check', () => {
   })
 })
 
+describe('relay help', () => {
+  test('returns ephemeral help text with all commands', async () => {
+    const result = await handleRelay(makeInteraction('help'), { SESSION_KV: createMockKV() })
+    expect(result.type).toBe(4)
+    expect(result.data.flags).toBe(64)
+    expect(result.data.content).toContain('/relay start')
+    expect(result.data.content).toContain('/relay status')
+    expect(result.data.content).toContain('/relay delete')
+    expect(result.data.content).toContain('/relay end')
+    expect(result.data.content).toContain('/relay post')
+    expect(result.data.content).toContain('/relay reveal')
+    expect(result.data.content).toContain('/relay terminate')
+    expect(result.data.content).toContain('基本の流れ')
+  })
+})
+
 describe('relay start', () => {
   test('rejects if relay already active', async () => {
     const kv = createMockKV()


### PR DESCRIPTION
## Summary
- `/relay help` サブコマンドを追加。全コマンドの使い方と基本の流れをエフェメラルで表示する
- コマンドの使い方がわからないという声への対応

## Test plan
- [x] `/relay help` がエフェメラルで全コマンドの説明を返すことをテストで確認
- [x] 全199テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)