### PR TITLE
fix(relay): bypass KV edge cache for relay reads

### DIFF
--- a/src/utils/relayStore.js
+++ b/src/utils/relayStore.js
@@ -3,7 +3,7 @@ const RELAY_TTL = 30 * 24 * 60 * 60 // 30日
 function relayKey(guildId) { return `relay-active:${guildId}` }
 
 export async function getRelay(kv, guildId) {
-  const raw = await kv.get(relayKey(guildId))
+  const raw = await kv.get(relayKey(guildId), 'text')
   return raw ? JSON.parse(raw) : null
 }
 


### PR DESCRIPTION
## Summary
- KVのエッジキャッシュにより、モーダルの「前の文章」フィールドに古いデータが表示される問題を修正
- `kv.get()` に `type: "text"` を明示指定してキャッシュをバイパス

## Test plan
- [ ] リレーで複数人が連続して文を追加し、モーダルの「前の文章」に直前の文が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)