### PR TITLE
fix(test): update KV mock for relay cache bypass

### DIFF
--- a/tests/relayButton.test.js
+++ b/tests/relayButton.test.js
@@ -5,7 +5,7 @@ import { handleModalSubmit } from '../src/interactions/modals.js'
 function createMockKV() {
   const store = new Map()
   return {
-    async get(key) { return store.get(key) ?? null },
+    async get(key, _opts) { return store.get(key) ?? null },
     async put(key, value, _opts) { store.set(key, value) },
     async delete(key) { store.delete(key) },
   }


### PR DESCRIPTION
## Summary
- #31 の `kv.get(key, 'text')` 変更に合わせてテストのKVモック引数を修正

## Test plan
- [ ] `npm test` で relayButton.test.js が PASS すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)